### PR TITLE
render left status on seperate goroutine

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -286,7 +286,7 @@ func (t *tbfe) renderView(v *backend.View, lay layout) {
 	for i := 0; i < t.window_layout.width; i++ {
 		termbox.SetCell(i, y, ' ', fg, bg)
 	}
-	t.renderLStatus(v, y, fg, bg)
+	go t.renderLStatus(v, y, fg, bg)
 	// The right status
 	rns := []rune(fmt.Sprintf("Tab Size:%d   %s", tabSize, "Go"))
 	x = t.window_layout.width - 1 - len(rns)


### PR DESCRIPTION
Show the Left side of the status bar with more consistency, rather than it occasionally flickering into view
